### PR TITLE
DM-7737: Python 3 port

### DIFF
--- a/python/lsst/validate/base/datum.py
+++ b/python/lsst/validate/base/datum.py
@@ -1,5 +1,7 @@
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function, division
+from builtins import object
+from past.builtins import basestring
 
 import numpy as np
 import astropy.units as u

--- a/python/lsst/validate/base/datum.py
+++ b/python/lsst/validate/base/datum.py
@@ -27,11 +27,17 @@ class QuantityAttributeMixin(object):
            `None`)."""
         return self._quantity
 
+    @staticmethod
+    def _is_non_quantity_type(q):
+        """Test if a quantity is a acceptable (`str`, `bool`, `int`, or
+        `None`), but not `astropy.quantity`."""
+        return isinstance(q, basestring) or isinstance(q, bool) or \
+            isinstance(q, int) or q is None
+
     @quantity.setter
     def quantity(self, q):
         assert isinstance(q, u.Quantity) or \
-            isinstance(q, basestring) or isinstance(q, bool) or \
-            isinstance(q, int) or q is None
+            QuantityAttributeMixin._is_non_quantity_type(q)
         self._quantity = q
 
     @property
@@ -41,8 +47,7 @@ class QuantityAttributeMixin(object):
         If the `quantity` is a `str` or `bool`, the unit is `None`.
         """
         q = self.quantity
-        if q is None or isinstance(q, basestring) or isinstance(q, bool) or \
-                isinstance(q, int):
+        if QuantityAttributeMixin._is_non_quantity_type(q):
             return None
         else:
             return q.unit
@@ -84,11 +89,7 @@ class QuantityAttributeMixin(object):
         q : `astropy.units.Quantity`, `str`, `int`, `bool` or `None`
             Astropy quantity.
         """
-        if isinstance(value, basestring) or \
-                isinstance(value, bool) or \
-                isinstance(value, int) or \
-                value is None:
-            # a str or bool
+        if QuantityAttributeMixin._is_non_quantity_type(value):
             _quantity = value
         elif isinstance(value, list):
             # an astropy quantity array
@@ -131,8 +132,7 @@ class Datum(QuantityAttributeMixin, JsonSerializationMixin):
         if quantity is None:
             self._quantity = None
         elif isinstance(quantity, u.Quantity) or \
-                isinstance(quantity, basestring) or \
-                isinstance(quantity, bool) or isinstance(quantity, int):
+                QuantityAttributeMixin._is_non_quantity_type(quantity):
             self.quantity = quantity
         elif unit is not None:
             self.quantity = u.Quantity(quantity, unit=unit)
@@ -164,9 +164,7 @@ class Datum(QuantityAttributeMixin, JsonSerializationMixin):
         """Datum as a `dict` compatible with overall `Job` JSON schema."""
         if self.quantity is None:
             v = None
-        elif isinstance(self.quantity, basestring) or \
-                isinstance(self.quantity, int) or \
-                isinstance(self.quantity, bool):
+        elif QuantityAttributeMixin._is_non_quantity_type(self.quantity):
             v = self.quantity
         elif len(self.quantity.shape) > 0:
             v = self.quantity.value.tolist()

--- a/python/lsst/validate/base/datummixin.py
+++ b/python/lsst/validate/base/datummixin.py
@@ -1,5 +1,6 @@
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function, division
+from builtins import object
 
 import astropy.units
 from .datum import Datum

--- a/python/lsst/validate/base/jsonmixin.py
+++ b/python/lsst/validate/base/jsonmixin.py
@@ -1,14 +1,16 @@
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function, division
+from builtins import object
 
 import abc
 import json
+from future.utils import with_metaclass
 
 
 __all__ = ['JsonSerializationMixin']
 
 
-class JsonSerializationMixin(object):
+class JsonSerializationMixin(with_metaclass(abc.ABCMeta, object)):
     """Mixin that provides JSON serialization support to subclasses.
 
     Subclasses must implement the `json` method. The method returns a `dict`
@@ -16,8 +18,6 @@ class JsonSerializationMixin(object):
     the conversion of iterables, numbers, strings, booleans and
     `JsonSerializationMixin`-compatible objects into a JSON-serialiable object.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
     def json(self):
@@ -52,7 +52,7 @@ class JsonSerializationMixin(object):
               })
         """
         json_dict = {}
-        for k, v in d.iteritems():
+        for k, v in d.items():
             json_dict[k] = JsonSerializationMixin._jsonify_value(v)
         return json_dict
 

--- a/python/lsst/validate/base/measurement.py
+++ b/python/lsst/validate/base/measurement.py
@@ -1,5 +1,6 @@
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function, division
+from future.utils import with_metaclass
 
 import abc
 import uuid
@@ -15,8 +16,12 @@ from .metric import Metric
 __all__ = ['MeasurementBase', 'DeserializedMeasurement']
 
 
-class MeasurementBase(QuantityAttributeMixin, JsonSerializationMixin,
-                      DatumAttributeMixin):
+class MeasurementBase(with_metaclass(abc.ABCMeta,
+                                     type('NewBase',
+                                          (QuantityAttributeMixin,
+                                           JsonSerializationMixin,
+                                           DatumAttributeMixin),
+                                          {}))):
     """Base class for Measurement classes.
 
     This class isn't instantiated directly. Instead, developers should
@@ -37,8 +42,6 @@ class MeasurementBase(QuantityAttributeMixin, JsonSerializationMixin,
        The :ref:`validate-base-measurement-class` page shows how to create
        measurement classes using `MeasurementBase`.
     """
-
-    __metaclass__ = abc.ABCMeta
 
     parameters = None
     """`dict` containing all input parameters used by this measurement.

--- a/python/lsst/validate/base/metric.py
+++ b/python/lsst/validate/base/metric.py
@@ -1,5 +1,6 @@
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function, division
+from past.builtins import basestring
 
 import operator
 from collections import OrderedDict
@@ -165,7 +166,7 @@ class Metric(JsonSerializationMixin):
                     elif isinstance(dep_item, dict):
                         # Likely a Datum
                         # in yaml, wrapper object is dict with single key-val
-                        name = dep_item.keys()[0]
+                        name = list(dep_item.keys())[0]
                         dep_item = dict(dep_item[name])
                         v = dep_item['value']
                         unit = dep_item['unit']

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function
+from builtins import zip
 
 import unittest
 

--- a/tests/test_measurementbase.py
+++ b/tests/test_measurementbase.py
@@ -146,7 +146,6 @@ class MeasurementBaseTestCase(unittest.TestCase):
             self.assertEqual(extra.quantity, m2.extras[k].quantity)
         for k, blob in self.meas._linked_blobs.items():
             for kk, datum in blob.datums.items():
-                print(m2._linked_blobs.keys())
                 self.assertEqual(datum.quantity, m2._linked_blobs[k].datums[kk].quantity)
 
     def test_datum_param(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function
+from builtins import zip
 
 import os
 import unittest

--- a/ups/validate_base.table
+++ b/ups/validate_base.table
@@ -1,4 +1,5 @@
 setupRequired(python)
+setupRequired(python_future)
 setupRequired(pyyaml)
 setupRequired(numpy)
 setupRequired(astropy)


### PR DESCRIPTION
Port of `validate_base` to Python 3. This is the result of

```
futurize -2 -x division_safe -n -w .
```

with some cleanup. Probably the most surprising change is the intermediate base class added to MeasurementBase.

Also adds the `python_future` dependency in the ups table file.