### PR TITLE
DM-9559: load YAML specifications into spec repo/set (WIP)

### DIFF
--- a/python/lsst/validate/base/spec.py
+++ b/python/lsst/validate/base/spec.py
@@ -7,7 +7,50 @@ from .jsonmixin import JsonSerializationMixin
 from .datum import Datum
 
 
-__all__ = ['ThresholdSpecification']
+__all__ = ['SpecificationSet', 'ThresholdSpecification']
+
+
+class SpecificationSet(object):
+    """A collection of Specification objects corresponding to metrics
+    in a MetricSet for a package, typically.
+
+    Parameters
+    ----------
+    name : `str`
+        Name of the `MetricSet` this ``SpecificationSet`` corresponds to.
+        Typically this is the name of a package.
+    specifications : `dict`
+        A dictionary of key-value pairs named after specifications, and
+        values are ``Specification`` instances.
+    """
+
+    def __init__(self, name, specifications):
+        self._name = name
+        self._specifications = specifications
+
+    @property
+    def name(self):
+        """Name of the `MetricSet` this ``SpecificationSet`` corresponds to
+        (immutable, `str`).
+
+        Typically this is the name of a package.
+        """
+
+    def __getitem__(self, name):
+        return self._specifications[name]
+
+    def __setitem__(self, name, specification):
+        # FIXME create a Specification base class for type testing
+        if not isinstance(specification, ThresholdSpecification):
+            msg = '{0!r} is not a Specification type'.format(specification)
+            raise RuntimeError(msg)
+        self._specifications[name] = specification
+
+    def __len__(self):
+        return len(self._specifications)
+
+    def __contains__(self, name):
+        return name in self._specifications
 
 
 class ThresholdSpecification(JsonSerializationMixin):

--- a/python/lsst/validate/base/spec.py
+++ b/python/lsst/validate/base/spec.py
@@ -49,6 +49,32 @@ class ThresholdSpecification(JsonSerializationMixin):
         return Datum(self.threshold, label=self.name)
 
     @classmethod
+    def from_yaml_doc(cls, yaml_doc):
+        """Create a `Specification` from a YAML document, inheriting from
+        referenced specifications and partials in a `SpecificationSet`.
+
+        **TODO:** add ``spec_set`` as an attribute so that specifications
+        can be inherited.
+
+        Parameters
+        ----------
+        yaml_doc : `dict`
+            Parsed YAML document for a single specification.
+        spec_set : `SpecificationSet`
+            SpecificationSet that may be used to resolve inheritance in a
+            ``yaml_doc``.
+
+        Returns
+        -------
+        spec : `Specification`
+            A `Specification` instance.
+        """
+        q = Datum._rebuild_quantity(
+            yaml_doc['threshold']['value'],
+            yaml_doc['threshold']['unit'])
+        return cls(yaml_doc['name'], q, yaml_doc['threshold']['operator'])
+
+    @classmethod
     def from_json(cls, json_data):
         """Construct a `ThresholdSpecification` from a JSON document.
 

--- a/python/lsst/validate/base/spec.py
+++ b/python/lsst/validate/base/spec.py
@@ -18,20 +18,8 @@ class Specification(QuantityAttributeMixin, JsonSerializationMixin):
     name : `str`
         Name of the specification level for a metric. LPM-17, for example,
         uses ``'design'``, ``'minimum'`` and ``'stretch'`` terminology.
-    quantity : `astropy.units.Quantity`, `float`, or `int`
+    quantity : `astropy.units.Quantity`
         The specification threshold level.
-    unit : `str`, optional
-        `astropy.units.Unit`-compatible `str` describing the units of
-        ``value`` (only necessary if `quantity` is a `float`).
-        An empty string (``''``) describes a unitless quantity.
-    filter_names : `list`, optional
-        A list of optical filter names that this specification applies to.
-        Set only if the specification level is dependent on the filter.
-    dependencies : `dict`, optional
-        A dictionary of named `Datum` values that must be known when making a
-        measurement against a specification level. Dependencies can be
-        accessed as attributes of the specification object. The names of
-        class attributes match keys in `dependencies`.
     """
 
     name = None
@@ -44,41 +32,9 @@ class Specification(QuantityAttributeMixin, JsonSerializationMixin):
     quantity = None
     """The specification threshold level (`astropy.units.Quantity`)."""
 
-    filter_names = None
-    """`list` of names of optical filters that this Specification level
-    applies to.
-
-    Default is `None` if the `Specification` is filter-independent.
-    """
-
-    dependencies = None
-    """`dict` of named `Datum` values that must be known when making a
-    measurement against a specification level.
-
-    Dependencies can also be accessed as attributes of the `Specification`
-    object. The names of class attributes match keys in `dependencies`.
-    """
-
-    def __init__(self, name, quantity, unit=None, filter_names=None,
-                 dependencies=None):
+    def __init__(self, name, quantity):
         self.name = name
-        if unit is not None:
-            self.quantity = quantity * u.Unit(unit)
-        else:
-            self.quantity = quantity
-        self.filter_names = filter_names
-        if dependencies:
-            self.dependencies = dependencies
-        else:
-            self.dependencies = {}
-
-    def __getattr__(self, key):
-        """Access dependencies with keys as attributes."""
-        if key in self.dependencies:
-            return self.dependencies[key]
-        else:
-            raise AttributeError("%r object has no attribute %r" %
-                                 (self.__class__, key))
+        self.quantity = quantity
 
     @property
     def datum(self):
@@ -100,12 +56,8 @@ class Specification(QuantityAttributeMixin, JsonSerializationMixin):
             Specification from JSON.
         """
         q = Datum._rebuild_quantity(json_data['value'], json_data['unit'])
-        deps = {k: Datum.from_json(v)
-                for k, v in json_data['dependencies'].items()}
         s = cls(name=json_data['name'],
-                quantity=q,
-                filter_names=json_data['filter_names'],
-                dependencies=deps)
+                quantity=q)
         return s
 
     @property
@@ -120,6 +72,4 @@ class Specification(QuantityAttributeMixin, JsonSerializationMixin):
         return JsonSerializationMixin.jsonify_dict({
             'name': self.name,
             'value': v,
-            'unit': self.unit_str,
-            'filter_names': self.filter_names,
-            'dependencies': self.dependencies})
+            'unit': self.unit_str})

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -2,11 +2,12 @@
 # See COPYRIGHT file at the top of the source tree.
 from __future__ import print_function, division
 
+import operator
 import unittest
 
 import astropy.units as u
 
-from lsst.validate.base import Specification
+from lsst.validate.base import ThresholdSpecification
 
 
 class SpecificationTestCase(unittest.TestCase):
@@ -20,21 +21,29 @@ class SpecificationTestCase(unittest.TestCase):
 
     def test_quantity(self):
         """Test creating and accessing a specification from a quantity."""
-        s = Specification('design', 5 * u.mag)
-        self.assertEqual(s.quantity.value, 5.)
-        self.assertEqual(s.unit, u.mag)
-        self.assertEqual(s.unit_str, 'mag')
+        s = ThresholdSpecification('design', 5 * u.mag, '<')
+        self.assertEqual(s.threshold.value, 5.)
+        self.assertEqual(s.threshold.unit, u.mag)
+        self.assertEqual(s.threshold.unit.to_string(), 'mag')
+        self.assertEqual(s.operator_str, '<')
+        self.assertEqual(s.operator, operator.lt)
+        # Test the check method and unit equivalencies
+        self.assertTrue(s.check(2. * u.mag))
+        self.assertTrue(s.check(2000. * u.mmag))
+        self.assertFalse(s.check(7. * u.mag))
+        self.assertFalse(s.check(7000. * u.mmag))
 
         # test json output
         json_data = s.json
         self.assertEqual(json_data['name'], 'design')
-        self.assertEqual(json_data['value'], 5.)
-        self.assertEqual(json_data['unit'], 'mag')
+        self.assertEqual(json_data['threshold']['value'], 5.)
+        self.assertEqual(json_data['threshold']['unit'], 'mag')
+        self.assertEqual(json_data['threshold']['operator'], '<')
 
         # rebuild from json
-        s2 = Specification.from_json(json_data)
+        s2 = ThresholdSpecification.from_json(json_data)
         self.assertEqual(s.name, s2.name)
-        self.assertEqual(s.quantity, s2.quantity)
+        self.assertEqual(s.threshold, s2.threshold)
 
         # test datum output
         d = s.datum
@@ -43,26 +52,46 @@ class SpecificationTestCase(unittest.TestCase):
 
     def test_unitless(self):
         """Test unitless specifications."""
-        s = Specification('design', 100. * u.dimensionless_unscaled)
-        self.assertEqual(s.quantity.value, 100.)
-        self.assertEqual(s.unit, u.dimensionless_unscaled)
-        self.assertEqual(s.unit_str, '')
+        s = ThresholdSpecification('design',
+                                   100. * u.dimensionless_unscaled, '<')
+        self.assertEqual(s.threshold.value, 100.)
+        self.assertEqual(s.threshold.unit, u.dimensionless_unscaled)
+        self.assertEqual(s.threshold.unit.to_string(), '')
+        # Test the check method
+        self.assertTrue(s.check(99. * u.dimensionless_unscaled))
+        self.assertFalse(s.check(101. * u.dimensionless_unscaled))
 
         # test json output
         json_data = s.json
         self.assertEqual(json_data['name'], 'design')
-        self.assertEqual(json_data['value'], 100.)
-        self.assertEqual(json_data['unit'], '')
+        self.assertEqual(json_data['threshold']['value'], 100.)
+        self.assertEqual(json_data['threshold']['unit'], '')
+        self.assertEqual(json_data['threshold']['operator'], '<')
 
         # rebuild from json
-        s2 = Specification.from_json(json_data)
+        s2 = ThresholdSpecification.from_json(json_data)
         self.assertEqual(s.name, s2.name)
-        self.assertEqual(s.quantity, s2.quantity)
+        self.assertEqual(s.threshold, s2.threshold)
 
         # test datum output
         d = s.datum
         self.assertEqual(d.quantity, 100. * u.dimensionless_unscaled)
         self.assertEqual(d.label, 'design')
+
+    def test_operator_conversion(self):
+        """Tests for Metric.convert_operator_str."""
+        self.assertTrue(
+            ThresholdSpecification.convert_operator_str('>=')(7, 7))
+        self.assertTrue(
+            ThresholdSpecification.convert_operator_str('>')(7, 5))
+        self.assertTrue(
+            ThresholdSpecification.convert_operator_str('<')(5, 7))
+        self.assertTrue(
+            ThresholdSpecification.convert_operator_str('<=')(7, 7))
+        self.assertTrue(
+            ThresholdSpecification.convert_operator_str('==')(7, 7))
+        self.assertTrue(
+            ThresholdSpecification.convert_operator_str('!=')(7, 5))
 
 
 if __name__ == "__main__":

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -94,5 +94,40 @@ class SpecificationTestCase(unittest.TestCase):
             ThresholdSpecification.convert_operator_str('!=')(7, 5))
 
 
+class TestSimpleYamlDeserialization(unittest.TestCase):
+    """Test building a ThresholdSpecification from a YAML doc without
+    partials or inheritance.
+    """
+
+    def setUp(self):
+        # Python dict as a Specification YAML doc
+        # FIXME there's no provenance query yet
+        self.yaml_doc = {
+            'name': 'design_gri',
+            'metric': 'PA1',
+            'threshold': {
+                'value': 5.0,
+                'unit': 'mmag',
+                'operator': '<='
+            }
+        }
+        # Build the spec
+        self.s = ThresholdSpecification.from_yaml_doc(self.yaml_doc)
+
+    def test_threshold_operator(self):
+        self.assertEqual(self.yaml_doc['threshold']['operator'],
+                         self.s.operator_str)
+
+    def test_threshold_quantity(self):
+        self.assertEqual(self.yaml_doc['threshold']['value'],
+                         self.s.threshold.value)
+        self.assertEqual(self.yaml_doc['threshold']['unit'],
+                         self.s.threshold.unit.to_string())
+
+    def test_name(self):
+        self.assertEqual(self.yaml_doc['name'],
+                         self.s.name)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_specification.py
+++ b/tests/test_specification.py
@@ -6,7 +6,7 @@ import unittest
 
 import astropy.units as u
 
-from lsst.validate.base import Specification, Datum
+from lsst.validate.base import Specification
 
 
 class SpecificationTestCase(unittest.TestCase):
@@ -35,32 +35,6 @@ class SpecificationTestCase(unittest.TestCase):
         s2 = Specification.from_json(json_data)
         self.assertEqual(s.name, s2.name)
         self.assertEqual(s.quantity, s2.quantity)
-        self.assertEqual(s.filter_names, s2.filter_names)
-
-        # test datum output
-        d = s.datum
-        self.assertEqual(d.quantity, 5. * u.mag)
-        self.assertEqual(d.label, 'design')
-
-    def test_from_value(self):
-        """Test creating a specification from a value."""
-        s = Specification('design', 5., unit='mag')
-        self.assertEqual(s.quantity.value, 5.)
-        self.assertEqual(s.unit, u.mag)
-        self.assertEqual(s.unit_str, 'mag')
-        self.assertEqual(s.name, 'design')
-
-        # test json output
-        json_data = s.json
-        self.assertEqual(json_data['name'], 'design')
-        self.assertEqual(json_data['value'], 5.)
-        self.assertEqual(json_data['unit'], 'mag')
-
-        # rebuild from json
-        s2 = Specification.from_json(json_data)
-        self.assertEqual(s.name, s2.name)
-        self.assertEqual(s.quantity, s2.quantity)
-        self.assertEqual(s.filter_names, s2.filter_names)
 
         # test datum output
         d = s.datum
@@ -69,9 +43,9 @@ class SpecificationTestCase(unittest.TestCase):
 
     def test_unitless(self):
         """Test unitless specifications."""
-        s = Specification('design', 100., unit='')
+        s = Specification('design', 100. * u.dimensionless_unscaled)
         self.assertEqual(s.quantity.value, 100.)
-        self.assertEqual(s.unit, u.Unit(''))
+        self.assertEqual(s.unit, u.dimensionless_unscaled)
         self.assertEqual(s.unit_str, '')
 
         # test json output
@@ -84,41 +58,11 @@ class SpecificationTestCase(unittest.TestCase):
         s2 = Specification.from_json(json_data)
         self.assertEqual(s.name, s2.name)
         self.assertEqual(s.quantity, s2.quantity)
-        self.assertEqual(s.filter_names, s2.filter_names)
 
         # test datum output
         d = s.datum
-        self.assertEqual(d.quantity, 100. * u.Unit(''))
+        self.assertEqual(d.quantity, 100. * u.dimensionless_unscaled)
         self.assertEqual(d.label, 'design')
-
-    def test_unitless_int(self):
-        """Test that a specification can be a unitless integer (count)."""
-        s = Specification('design', 10)
-        self.assertEqual(s.quantity, 10)
-
-        # test JSON output
-        json_data = s.json
-        self.assertEqual(json_data['value'], 10)
-
-        # rebuild from JSON
-        s2 = Specification.from_json(json_data)
-        self.assertEqual(s.quantity, s2.quantity)
-
-    def test_filters(self):
-        """Test setting filter dependencies."""
-        filter_names = ['u', 'g']
-        s = Specification('design', 5 * u.mag, filter_names=filter_names)
-        for filter_name in s.filter_names:
-            self.assertIn(filter_name, filter_names)
-        self.assertEqual(len(filter_names), len(s.filter_names))
-
-    def test_dependency_access(self):
-        deps = {'a': Datum(5., 'mag')}
-        s = Specification('design', 0., '', dependencies=deps)
-        self.assertEqual(s.a.quantity, 5. * u.mag)
-        json_data = s.json
-        self.assertEqual(json_data['dependencies']['a']['value'], 5.)
-        self.assertEqual(json_data['dependencies']['a']['unit'], 'mag')
 
 
 if __name__ == "__main__":

--- a/tests/test_specification_set.py
+++ b/tests/test_specification_set.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# See COPYRIGHT file at the top of the source tree.
+from __future__ import print_function, division
+
+import unittest
+
+from lsst.validate.base.spec import SpecificationSet, ThresholdSpecification
+
+
+class TestSimpleSpecificationSet(unittest.TestCase):
+    """Test a small specification set."""
+
+    def setUp(self):
+        self.pa1_design_gri_doc = {
+            'name': 'design_gri',
+            'metric': 'PA1',
+            'threshold': {
+                'value': 5.0,
+                'unit': 'mmag',
+                'operator': '<='
+            }
+        }
+        pa1_design_gri = ThresholdSpecification.from_yaml_doc(
+            self.pa1_design_gri_doc)
+
+        self.pa1_stretch_gri_doc = {
+            'name': 'stretch_gri',
+            'metric': 'PA1',
+            'threshold': {
+                'value': 3.0,
+                'unit': 'mmag',
+                'operator': '<='
+            }
+        }
+        pa1_stretch_gri = ThresholdSpecification.from_yaml_doc(
+            self.pa1_stretch_gri_doc)
+
+        specifications = {
+            pa1_design_gri.name: pa1_design_gri,
+        }
+        self.spec_set = SpecificationSet('validate_drp', specifications)
+        self.spec_set[pa1_stretch_gri.name] = pa1_stretch_gri
+
+    def test_len(self):
+        self.assertEqual(len(self.spec_set), 2)
+
+    def test_contains(self):
+        self.assertTrue('design_gri' in self.spec_set)
+        self.assertTrue('stretch_gri' in self.spec_set)
+
+    def test_getitem(self):
+        # FIXME better to test object equality
+        self.assertEqual(self.spec_set['design_gri'].name, 'design_gri')
+        self.assertEqual(self.spec_set['stretch_gri'].name, 'stretch_gri')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In progress work to create a `SpecificationRepo` and `SpecificationSet` and demonstrate that YAML files from `validate_metrics` can be loaded into `Specification` instances.

**Progress:**

- [x] Minimum viable specification following sqr-017.lsst.io: ThresholdSpecification.
- [x] Build a ThresholdSpecification from a plain YAML document (no partials, no inheritance).
- [ ] Create SpecificationSet **in progress**.
- [x] ~Create tools to parse and work with fully qualified metric and specification names (`nameutils` module?)~ See DM-9850.
- [ ] Create SpecificationRepo
- [ ] Add provenance query as a dict to Specification
- [ ] Add Specification inheritance
- [ ] Add Specification partials