### PR TITLE
DM-9850: Create a Name class for semantic package, metric and specification naming

### DIFF
--- a/python/lsst/validate/base/__init__.py
+++ b/python/lsst/validate/base/__init__.py
@@ -11,6 +11,7 @@ except:
 
 from .errors import *
 from .datum import *
+from .naming import *
 from .spec import *
 from .metric import *
 from .measurement import *

--- a/python/lsst/validate/base/naming.py
+++ b/python/lsst/validate/base/naming.py
@@ -37,7 +37,7 @@ class Name(object):
 
     Raises
     ------
-    ValueError
+    TypeError
        Raised when arguments cannot be parsed or conflict (for example, if two
        different package names are specified through two different fields).
     """
@@ -54,22 +54,30 @@ class Name(object):
                 self._spec = package.spec
             else:
                 # Assume a string type
-                self._package, self._metric, self._spec = \
-                    Name._parse_fqn_string(package)
+                try:
+                    self._package, self._metric, self._spec = \
+                        Name._parse_fqn_string(package)
+                except ValueError as e:
+                    # Want to raise TypeError in __init__
+                    raise TypeError(str(e))
 
         if metric is not None:
             if isinstance(metric, Name):
                 if metric.has_metric is False:
-                    raise ValueError(
+                    raise TypeError(
                         'metric={metric!r} argument does not include metric '
                         'information.'.format(metric=metric))
                 _package = metric.package
                 _metric = metric.metric
                 _spec = metric.spec
             else:
-                _package, _metric = \
-                    Name._parse_metric_name_string(metric)
-                _spec = None
+                try:
+                    _package, _metric = \
+                        Name._parse_metric_name_string(metric)
+                    _spec = None
+                except ValueError as e:
+                    # Want to raise TypeError in __init__
+                    raise TypeError(str(e))
 
             # Ensure none of the new information is inconsistent
             self._init_new_package_info(_package)
@@ -79,15 +87,19 @@ class Name(object):
         if spec is not None:
             if isinstance(spec, Name):
                 if spec.has_spec is False:
-                    raise ValueError(
+                    raise TypeError(
                         'spec={spec!r} argument does not include '
                         'specification information'.format(spec=spec))
                 _package = spec.package
                 _metric = spec.metric
                 _spec = spec.spec
             else:
-                _package, _metric, _spec = \
-                    Name._parse_spec_name_string(spec)
+                try:
+                    _package, _metric, _spec = \
+                        Name._parse_spec_name_string(spec)
+                except ValueError as e:
+                    # want to raise TypeError in __init__
+                    raise TypeError(str(e))
 
             # Ensure none of the new information is inconsistent
             self._init_new_package_info(_package)
@@ -98,9 +110,9 @@ class Name(object):
         if self._package is not None \
                 and self._spec is not None \
                 and self._metric is None:
-            raise ValueError("Missing 'metric' given package={package!r} "
-                             "spec={spec!r}".format(package=package,
-                                                    spec=spec))
+            raise TypeError("Missing 'metric' given package={package!r} "
+                            "spec={spec!r}".format(package=package,
+                                                   spec=spec))
 
     def _init_new_package_info(self, package):
         """Check and add new package information (for __init__)."""
@@ -110,7 +122,7 @@ class Name(object):
                 self._package = package
             else:
                 message = 'You provided a conflicting package={package!r}.'
-                raise ValueError(message.format(package=package))
+                raise TypeError(message.format(package=package))
 
     def _init_new_metric_info(self, metric):
         """Check and add new metric information (for __init__)."""
@@ -120,7 +132,7 @@ class Name(object):
                 self._metric = metric
             else:
                 message = 'You provided a conflicting metric={metric!r}.'
-                raise ValueError(message.format(metric=metric))
+                raise TypeError(message.format(metric=metric))
 
     def _init_new_spec_info(self, spec):
         """Check and add new spec information (for __init__)."""
@@ -130,7 +142,7 @@ class Name(object):
                 self._spec = spec
             else:
                 message = 'You provided a conflicting spec={spec!r}.'
-                raise ValueError(message.format(spec=spec))
+                raise TypeError(message.format(spec=spec))
 
     @staticmethod
     def _parse_fqn_string(fqn):

--- a/python/lsst/validate/base/naming.py
+++ b/python/lsst/validate/base/naming.py
@@ -187,6 +187,31 @@ class Name(object):
             (self.metric == other.metric) and \
             (self.spec == other.spec)
 
+    def __contains__(self, name):
+        """Test if another Name is contained by this Name."""
+        contains = True  # tests will disprove membership
+
+        if self.is_package:
+            if name.is_package:
+                contains = False
+            else:
+                contains = self.package == name.package
+
+        elif self.is_metric:
+            if name.is_metric:
+                contains = False
+            else:
+                if self.has_package or name.has_package:
+                    contains = contains and (self.package == name.package)
+
+                contains = contains and (self.metric == name.metric)
+
+        else:
+            # Must be a specification, which cannot 'contain' anything
+            contains = False
+
+        return contains
+
     @property
     def has_package(self):
         """`True` if this object contains a package name (`bool`)."""

--- a/python/lsst/validate/base/naming.py
+++ b/python/lsst/validate/base/naming.py
@@ -216,6 +216,9 @@ class Name(object):
             (self.metric == other.metric) and \
             (self.spec == other.spec)
 
+    def __hash__(self):
+        return hash((self.package, self.metric, self.spec))
+
     def __contains__(self, name):
         """Test if another Name is contained by this Name."""
         contains = True  # tests will disprove membership

--- a/python/lsst/validate/base/naming.py
+++ b/python/lsst/validate/base/naming.py
@@ -11,6 +11,8 @@ class Name(object):
     """Semantic name of a package, `lsst.validate.base.Metric` or
     `lsst.validate.base.Specification` in the `lsst.validate` framework.
 
+    ``Name``\ s are immutable.
+
     Parameters
     ----------
     package : `str` or `Name`
@@ -41,18 +43,18 @@ class Name(object):
     """
 
     def __init__(self, package=None, metric=None, spec=None):
-        self.package = None
-        self.metric = None
-        self.spec = None
+        self._package = None
+        self._metric = None
+        self._spec = None
 
         if package is not None:
             if isinstance(package, Name):
-                self.package = package.package
-                self.metric = package.metric
-                self.spec = package.spec
+                self._package = package.package
+                self._metric = package.metric
+                self._spec = package.spec
             else:
                 # Assume a string type
-                self.package, self.metric, self.spec = \
+                self._package, self._metric, self._spec = \
                     Name._parse_fqn_string(package)
 
         if metric is not None:
@@ -93,9 +95,9 @@ class Name(object):
             self._init_new_spec_info(_spec)
 
         # Ensure the name doesn't have a metric gap
-        if self.package is not None \
-                and self.spec is not None \
-                and self.metric is None:
+        if self._package is not None \
+                and self._spec is not None \
+                and self._metric is None:
             raise ValueError("Missing 'metric' given package={package!r} "
                              "spec={spec!r}".format(package=package,
                                                     spec=spec))
@@ -103,9 +105,9 @@ class Name(object):
     def _init_new_package_info(self, package):
         """Check and add new package information (for __init__)."""
         if package is not None:
-            if self.package is None or package == self.package:
+            if self._package is None or package == self._package:
                 # There's new or consistent package info
-                self.package = package
+                self._package = package
             else:
                 message = 'You provided a conflicting package={package!r}.'
                 raise ValueError(message.format(package=package))
@@ -113,9 +115,9 @@ class Name(object):
     def _init_new_metric_info(self, metric):
         """Check and add new metric information (for __init__)."""
         if metric is not None:
-            if self.metric is None or metric == self.metric:
+            if self._metric is None or metric == self._metric:
                 # There's new or consistent metric info
-                self.metric = metric
+                self._metric = metric
             else:
                 message = 'You provided a conflicting metric={metric!r}.'
                 raise ValueError(message.format(metric=metric))
@@ -123,9 +125,9 @@ class Name(object):
     def _init_new_spec_info(self, spec):
         """Check and add new spec information (for __init__)."""
         if spec is not None:
-            if self.spec is None or spec == self.spec:
+            if self._spec is None or spec == self._spec:
                 # There's new or consistent spec info
-                self.spec = spec
+                self._spec = spec
             else:
                 message = 'You provided a conflicting spec={spec!r}.'
                 raise ValueError(message.format(spec=spec))
@@ -181,6 +183,21 @@ class Name(object):
             # Don't know what this string is
             raise ValueError('Cannot parse specification name: '
                              '{0!r}'.format(name))
+
+    @property
+    def package(self):
+        """Package name (`str`)."""
+        return self._package
+
+    @property
+    def metric(self):
+        """Metric name (`str`)."""
+        return self._metric
+
+    @property
+    def spec(self):
+        """Specification name (`str`)."""
+        return self._spec
 
     def __eq__(self, other):
         return (self.package == other.package) and \

--- a/python/lsst/validate/base/naming.py
+++ b/python/lsst/validate/base/naming.py
@@ -8,14 +8,179 @@ __all__ = ['Name']
 
 
 class Name(object):
-    """Semantic name of a Metric or Specification in the
-    lsst.validate framework.
+    """Semantic name of a package, `lsst.validate.base.Metric` or
+    `lsst.validate.base.Specification` in the `lsst.validate` framework.
+
+    Parameters
+    ----------
+    package : `str` or `Name`
+       Name of the package, either as a string (``'validate_drp'``,
+       for example) or as a Name object (``Name(package='validate_drp')``
+       for example).
+
+       The ``package`` field can also be fully specified::
+
+           Name(package='validate_drp.PA1.design_gri')
+
+       or used as the sole positional argument::
+
+           Name('validate_drp.PA1.design_gri')
+    metric : `str` or `Name`
+       Name of the metric. The name can be relative (``'PA'``) or
+       fully-specified (``'validate_drp.PA1'``).
+    spec : `str` or `Name`
+       Name of the specification. The name can be bare (``'design_gri'``),
+       metric-relative (``'PA1.design_gri'``) or fully-specified
+       (``'validate_drp.PA1.design_gri'``)
+
+    Raises
+    ------
+    ValueError
+       Raised when arguments cannot be parsed or conflict (for example, if two
+       different package names are specified through two different fields).
     """
 
     def __init__(self, package=None, metric=None, spec=None):
-        self.package = package
-        self.metric = metric
-        self.spec = spec
+        self.package = None
+        self.metric = None
+        self.spec = None
+
+        if package is not None:
+            if isinstance(package, Name):
+                self.package = package.package
+                self.metric = package.metric
+                self.spec = package.spec
+            else:
+                # Assume a string type
+                self.package, self.metric, self.spec = \
+                    Name._parse_fqn_string(package)
+
+        if metric is not None:
+            if isinstance(metric, Name):
+                if metric.has_metric is False:
+                    raise ValueError(
+                        'metric={metric!r} argument does not include metric '
+                        'information.'.format(metric=metric))
+                _package = metric.package
+                _metric = metric.metric
+                _spec = metric.spec
+            else:
+                _package, _metric = \
+                    Name._parse_metric_name_string(metric)
+                _spec = None
+
+            # Ensure none of the new information is inconsistent
+            self._init_new_package_info(_package)
+            self._init_new_metric_info(_metric)
+            self._init_new_spec_info(_spec)
+
+        if spec is not None:
+            if isinstance(spec, Name):
+                if spec.has_spec is False:
+                    raise ValueError(
+                        'spec={spec!r} argument does not include '
+                        'specification information'.format(spec=spec))
+                _package = spec.package
+                _metric = spec.metric
+                _spec = spec.spec
+            else:
+                _package, _metric, _spec = \
+                    Name._parse_spec_name_string(spec)
+
+            # Ensure none of the new information is inconsistent
+            self._init_new_package_info(_package)
+            self._init_new_metric_info(_metric)
+            self._init_new_spec_info(_spec)
+
+        # Ensure the name doesn't have a metric gap
+        if self.package is not None \
+                and self.spec is not None \
+                and self.metric is None:
+            raise ValueError("Missing 'metric' given package={package!r} "
+                             "spec={spec!r}".format(package=package,
+                                                    spec=spec))
+
+    def _init_new_package_info(self, package):
+        """Check and add new package information (for __init__)."""
+        if package is not None:
+            if self.package is None or package == self.package:
+                # There's new or consistent package info
+                self.package = package
+            else:
+                message = 'You provided a conflicting package={package!r}.'
+                raise ValueError(message.format(package=package))
+
+    def _init_new_metric_info(self, metric):
+        """Check and add new metric information (for __init__)."""
+        if metric is not None:
+            if self.metric is None or metric == self.metric:
+                # There's new or consistent metric info
+                self.metric = metric
+            else:
+                message = 'You provided a conflicting metric={metric!r}.'
+                raise ValueError(message.format(metric=metric))
+
+    def _init_new_spec_info(self, spec):
+        """Check and add new spec information (for __init__)."""
+        if spec is not None:
+            if self.spec is None or spec == self.spec:
+                # There's new or consistent spec info
+                self.spec = spec
+            else:
+                message = 'You provided a conflicting spec={spec!r}.'
+                raise ValueError(message.format(spec=spec))
+
+    @staticmethod
+    def _parse_fqn_string(fqn):
+        """Parse a fully-qualified name.
+        """
+        parts = fqn.split('.')
+        if len(parts) == 1:
+            # Must be a package name alone
+            return parts[0], None, None
+        if len(parts) == 2:
+            # Must be a fully-qualified metric name
+            return parts[0], parts[1], None
+        elif len(parts) == 3:
+            # Must be a fully-qualified specification name
+            return parts
+        else:
+            # Don't know what this string is
+            raise ValueError('Cannot parse fully qualified name: '
+                             '{0!r}'.format(fqn))
+
+    @staticmethod
+    def _parse_metric_name_string(name):
+        """Parse a metric name."""
+        parts = name.split('.')
+        if len(parts) == 2:
+            # Must be a fully-qualified metric name
+            return parts[0], parts[1]
+        elif len(parts) == 1:
+            # A bare metric name
+            return None, parts[0]
+        else:
+            # Don't know what this string is
+            raise ValueError('Cannot parse metric name: '
+                             '{0!r}'.format(name))
+
+    @staticmethod
+    def _parse_spec_name_string(name):
+        """Parse a specification name."""
+        parts = name.split('.')
+        if len(parts) == 1:
+            # Bare specification name
+            return None, None, parts[0]
+        elif len(parts) == 2:
+            # metric-relative specification name
+            return None, parts[0], parts[1]
+        elif len(parts) == 3:
+            # fully-qualified specification name
+            return parts
+        else:
+            # Don't know what this string is
+            raise ValueError('Cannot parse specification name: '
+                             '{0!r}'.format(name))
 
     def __eq__(self, other):
         return (self.package == other.package) and \

--- a/python/lsst/validate/base/naming.py
+++ b/python/lsst/validate/base/naming.py
@@ -1,0 +1,193 @@
+# See COPYRIGHT file at the top of the source tree.
+"""Tools for building and parsing fully-qualified names of metrics and
+specifications.
+"""
+from __future__ import print_function
+
+__all__ = ['Name']
+
+
+class Name(object):
+    """Semantic name of a Metric or Specification in the
+    lsst.validate framework.
+    """
+
+    def __init__(self, package=None, metric=None, spec=None):
+        self.package = package
+        self.metric = metric
+        self.spec = spec
+
+    @property
+    def has_package(self):
+        """`True` if this object contains a package name (`bool`)."""
+        if self.package is not None:
+            return True
+        else:
+            return False
+
+    @property
+    def has_spec(self):
+        """`True` if this object contains a specification name, either
+        relative or fully-qualified (`bool`).
+        """
+        if self.spec is not None:
+            return True
+        else:
+            return False
+
+    @property
+    def has_metric(self):
+        """`True` if this object contains a metric name, either
+        relative or fully-qualified (`bool`).
+        """
+        if self.metric is not None:
+            return True
+        else:
+            return False
+
+    @property
+    def has_relative(self):
+        """`True` if a relative specification name can be formed from this
+        object, i.e., `metric` and `spec` attributes are set (`bool`).
+        """
+        if self.is_spec and self.has_metric:
+            return True
+        else:
+            return False
+
+    @property
+    def is_package(self):
+        """`True` if this object is a package name (`bool`)."""
+        if self.has_package and \
+                self.is_metric is False and \
+                self.is_spec is False:
+            return True
+        else:
+            return False
+
+    @property
+    def is_metric(self):
+        """`True` if this object is a metric name, either relative or
+        fully-qualified (`bool`).
+        """
+        if self.has_metric is True and self.has_spec is False:
+            return True
+        else:
+            return False
+
+    @property
+    def is_spec(self):
+        """`True` if this object is a specification name, either relative or
+        fully-qualified (`bool`).
+        """
+        if self.has_spec is True:
+            return True
+        else:
+            return False
+
+    @property
+    def is_fq(self):
+        """`True` if this object is a fully-qualified name of either a
+        package, metric or specification (`bool`).
+
+        Examples:
+
+        - ``'validate_drp'`` is a fully-qualified package name.
+        - ``'validate_drp.PA1'`` is a fully-qualified metric name.
+        - ``'validate_drp.PA1.design_gri'`` is a fully-qualified specification
+          name.
+        """
+        if self.is_package:
+            # package names are by definition fully qualified
+            return True
+        elif self.is_metric and self.has_package:
+            # fully-qualified metric
+            return True
+        elif self.is_spec and self.has_package and self.has_metric:
+            # fully-qualified specification
+            return True
+        else:
+            return False
+
+    @property
+    def is_relative(self):
+        """`True` if this object is a specification name that's not
+        fully-qualified, but is relative to a metric name (`bool`).
+        relative to a base name. (`bool`).
+
+        For example, ``PA1.design_gri`` is a relative specification name.
+
+        Package and metric names are never relative.
+        """
+        if self.is_spec and \
+                self.has_metric is True and \
+                self.has_package is False:
+            return True
+        else:
+            return False
+
+    def __repr__(self):
+        if self.is_package:
+            return 'Name({self.package!r})'.format(self=self)
+        elif self.is_metric and not self.is_fq:
+            return 'Name(metric={self.metric!r})'.format(self=self)
+        elif self.is_metric and self.is_fq:
+            return 'Name({self.package!r}, {self.metric!r})'.format(
+                self=self)
+        elif self.is_spec and not self.is_fq and not self.is_relative:
+            return 'Name(spec={self.spec!r})'.format(
+                self=self)
+        elif self.is_spec and not self.is_fq and self.is_relative:
+            return 'Name(metric={self.metric!r}, spec={self.spec!r})'.format(
+                self=self)
+        else:
+            # Should be a fully-qualified specification
+            template = 'Name({self.package!r}, {self.metric!r}, {self.spec!r})'
+            return template.format(self=self)
+
+    def __str__(self):
+        if self.is_package:
+            return self.package
+        elif self.is_metric and not self.is_fq:
+            return self.metric
+        elif self.is_metric and self.is_fq:
+            return '{self.package}.{self.metric}'.format(self=self)
+        elif self.is_spec and not self.is_fq and not self.is_relative:
+            return self.spec
+        elif self.is_spec and not self.is_fq and self.is_relative:
+            return '{self.metric}.{self.spec}'.format(self=self)
+        else:
+            # Should be a fully-qualified specification
+            return '{self.package}.{self.metric}.{self.spec}'.format(
+                self=self)
+
+    @property
+    def fqn(self):
+        """The fully-qualified name (`str`).
+
+        Raises
+        ------
+        AttributeError
+           If the name is not a fully-qualified name (check `is_fq`)
+        """
+        if self.is_fq:
+            return str(self)
+        else:
+            message = '{self!r} is not a fully-qualified name'
+            raise AttributeError(message.format(self=self))
+
+    @property
+    def relative_name(self):
+        """The relative specification name (`str`).
+
+        Raises
+        ------
+        AttributeError
+           If the object does not represent a specification, or if a relative
+           name cannot be formed because the `metric` is None.
+        """
+        if self.has_relative:
+            return '{self.metric}.{self.spec}'.format(self=self)
+        else:
+            message = '{self!r} is not a relative specification name'
+            raise AttributeError(message.format(self=self))

--- a/python/lsst/validate/base/naming.py
+++ b/python/lsst/validate/base/naming.py
@@ -17,6 +17,11 @@ class Name(object):
         self.metric = metric
         self.spec = spec
 
+    def __eq__(self, other):
+        return (self.package == other.package) and \
+            (self.metric == other.metric) and \
+            (self.spec == other.spec)
+
     @property
     def has_package(self):
         """`True` if this object contains a package name (`bool`)."""

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -170,6 +170,12 @@ class FullyQualifiedMetricName(unittest.TestCase):
             self.name == Name(package='validate_base',
                               metric='PA1'))
 
+    def test_hash(self):
+        self.assertEqual(
+            hash(self.name),
+            hash(Name('validate_drp.PA1'))
+        )
+
     def test_contains(self):
         self.assertTrue(
             Name('validate_drp.PA1.design_gri') in self.name
@@ -253,6 +259,16 @@ class MetricName(unittest.TestCase):
             self.name == Name(package='validate_drp', metric='PA2'))
         self.assertFalse(
             self.name == Name(metric='PA2'))
+
+    def test_hash(self):
+        self.assertEqual(
+            hash(self.name),
+            hash(Name(metric='PA1'))
+        )
+        self.assertNotEqual(
+            hash(self.name),
+            hash(Name(package='vaidate_drp', metric='PA1'))
+        )
 
     def test_contains(self):
         self.assertTrue(
@@ -361,6 +377,20 @@ class FullyQualifiedSpecificationName(unittest.TestCase):
                               spec='design_gri'))
         self.assertFalse(
             self.name == Name(spec='design_gri'))
+
+    def test_hash(self):
+        self.assertEqual(
+            hash(self.name),
+            hash(Name('validate_drp.PA1.design_gri'))
+        )
+        self.assertNotEqual(
+            hash(self.name),
+            hash(Name('validate_drp.PA1.minimum'))
+        )
+        self.assertNotEqual(
+            hash(self.name),
+            hash(Name(spec='PA1.design_gri'))
+        )
 
     def test_has_package(self):
         self.assertTrue(self.name.has_package)

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -41,6 +41,17 @@ class FullyQualifiedMetricName(unittest.TestCase):
             'validate_drp.PA1'
         )
 
+    def test_eq(self):
+        self.assertTrue(
+            self.name == Name(package='validate_drp', metric='PA1'))
+        self.assertFalse(
+            self.name == Name(package='validate_drp',
+                              metric='PA1',
+                              spec='design'))
+        self.assertFalse(
+            self.name == Name(package='validate_base',
+                              metric='PA1'))
+
     def test_has_package(self):
         self.assertTrue(self.name.has_package)
 
@@ -102,6 +113,14 @@ class MetricName(unittest.TestCase):
             str(self.name),
             'PA1'
         )
+
+    def test_eq(self):
+        self.assertTrue(
+            self.name == Name(metric='PA1'))
+        self.assertFalse(
+            self.name == Name(package='validate_drp', metric='PA2'))
+        self.assertFalse(
+            self.name == Name(metric='PA2'))
 
     def test_has_package(self):
         self.assertFalse(self.name.has_package)
@@ -169,6 +188,21 @@ class FullyQualifiedSpecificationName(unittest.TestCase):
             'validate_drp.PA1.design_gri'
         )
 
+    def test_eq(self):
+        self.assertTrue(
+            self.name == Name(package='validate_drp',
+                              metric='PA1',
+                              spec='design_gri'))
+        self.assertFalse(
+            self.name == Name(package='validate_drp',
+                              metric='PA1',
+                              spec='minimum'))
+        self.assertFalse(
+            self.name == Name(metric='PA1',
+                              spec='design_gri'))
+        self.assertFalse(
+            self.name == Name(spec='design_gri'))
+
     def test_has_package(self):
         self.assertTrue(self.name.has_package)
 
@@ -233,6 +267,16 @@ class RelativeSpecificationName(unittest.TestCase):
             'PA1.design_gri'
         )
 
+    def test_eq(self):
+        self.assertTrue(
+            self.name == Name(metric='PA1', spec='design_gri'))
+        self.assertFalse(
+            self.name == Name(package='validate_drp',
+                              metric='PA1',
+                              spec='design_gri'))
+        self.assertFalse(
+            self.name == Name(metric='PA1', spec='minimum'))
+
     def test_has_package(self):
         self.assertFalse(self.name.has_package)
 
@@ -294,6 +338,14 @@ class SpecificationName(unittest.TestCase):
             str(self.name),
             'design_gri'
         )
+
+    def test_eq(self):
+        self.assertTrue(
+            self.name == Name(spec='design_gri'))
+        self.assertFalse(
+            self.name == Name(metric='PA1', spec='design_gri'))
+        self.assertFalse(
+            self.name == Name(spec='minimum'))
 
     def test_has_package(self):
         self.assertFalse(self.name.has_package)
@@ -357,6 +409,15 @@ class PackageName(unittest.TestCase):
             str(self.name),
             'validate_drp'
         )
+
+    def test_eq(self):
+        self.assertTrue(
+            self.name == Name(package='validate_drp'))
+        self.assertFalse(
+            self.name == Name(package='validate_base'))
+        self.assertFalse(
+            self.name == Name(package='validate_drp',
+                              metric='PA1'))
 
     def test_has_package(self):
         self.assertTrue(self.name.has_package)

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -39,7 +39,7 @@ class NameConstructors(unittest.TestCase):
             Name('validate_drp.PA1', metric='PA1')
         )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Name(metric='validate_drp.PA1', package='validate_base')
 
     def test_metric_name(self):
@@ -51,7 +51,7 @@ class NameConstructors(unittest.TestCase):
         )
 
         # Using the wrong type of name
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Name(metric=Name(spec='design_gri'))
 
     def test_fully_qualified_specification_name(self):
@@ -98,7 +98,7 @@ class NameConstructors(unittest.TestCase):
             Name(metric='PA1', spec='PA1.design_gri')
         )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Name(metric='PA2', spec='PA1.design_gri')
 
     def test_specification_name(self):
@@ -112,7 +112,7 @@ class NameConstructors(unittest.TestCase):
         )
 
         # Using the wrong type of Name
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Name(spec=Name('validate_drp.PA1'))
 
     def test_package_name(self):
@@ -316,14 +316,14 @@ class FullyQualifiedSpecificationName(unittest.TestCase):
     def test_spec_name(self):
         self.assertEqual(self.name.spec, 'design_gri')
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Name('validate_drp.PA1.design_gri', spec='minimum')
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Name('validate_drp.PA1.design_gri', metric='PA2')
 
         # Can't create a specification with a metric gap
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             Name(package='validate_drp', spec='design')
 
     def test_fqn(self):

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -170,6 +170,20 @@ class FullyQualifiedMetricName(unittest.TestCase):
             self.name == Name(package='validate_base',
                               metric='PA1'))
 
+    def test_contains(self):
+        self.assertTrue(
+            Name('validate_drp.PA1.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp.PA2.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp.PA2') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp') in self.name
+        )
+
     def test_has_package(self):
         self.assertTrue(self.name.has_package)
 
@@ -239,6 +253,23 @@ class MetricName(unittest.TestCase):
             self.name == Name(package='validate_drp', metric='PA2'))
         self.assertFalse(
             self.name == Name(metric='PA2'))
+
+    def test_contains(self):
+        self.assertTrue(
+            Name(spec='PA1.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp.PA1.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp.PA2.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp.PA2') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp') in self.name
+        )
 
     def test_has_package(self):
         self.assertFalse(self.name.has_package)
@@ -475,6 +506,23 @@ class SpecificationName(unittest.TestCase):
         self.assertFalse(
             self.name == Name(spec='minimum'))
 
+    def test_contains(self):
+        self.assertFalse(
+            Name(spec='design_gri') in self.name
+        )
+        self.assertFalse(
+            Name(spec='PA1.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp.PA1.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp.PA1') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp') in self.name
+        )
+
     def test_has_package(self):
         self.assertFalse(self.name.has_package)
 
@@ -549,6 +597,20 @@ class PackageName(unittest.TestCase):
         self.assertFalse(
             self.name == Name(package='validate_drp',
                               metric='PA1'))
+
+    def test_contains(self):
+        self.assertFalse(
+            Name(spec='PA1.design_gri') in self.name
+        )
+        self.assertTrue(
+            Name('validate_drp.PA1.design_gri') in self.name
+        )
+        self.assertTrue(
+            Name('validate_drp.PA2.design_gri') in self.name
+        )
+        self.assertFalse(
+            Name('validate_drp') in self.name
+        )
 
     def test_has_package(self):
         self.assertTrue(self.name.has_package)

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -6,6 +6,124 @@ import unittest
 from lsst.validate.base.naming import Name
 
 
+class NameConstructors(unittest.TestCase):
+    """Tests for Name constructor patterns."""
+
+    def test_fully_qualified_metric_name(self):
+        """Creating a fully-qualified metric name."""
+        ref_name = Name(package='validate_drp', metric='PA1')
+
+        self.assertEqual(
+            ref_name,
+            Name(metric='validate_drp.PA1')
+        )
+
+        # Use a Name to specifify metric field
+        self.assertEqual(
+            ref_name,
+            Name(metric=Name(package='validate_drp', metric='PA1'))
+        )
+
+        self.assertEqual(
+            ref_name,
+            Name(metric='validate_drp.PA1', package='validate_drp')
+        )
+
+        self.assertEqual(
+            ref_name,
+            Name('validate_drp.PA1')
+        )
+
+        self.assertEqual(
+            ref_name,
+            Name('validate_drp.PA1', metric='PA1')
+        )
+
+        with self.assertRaises(ValueError):
+            Name(metric='validate_drp.PA1', package='validate_base')
+
+    def test_metric_name(self):
+        """Creating a metric name."""
+        # Using a Name as an argument
+        self.assertEqual(
+            Name(metric='PA1'),
+            Name(metric=Name(metric='PA1'))
+        )
+
+        # Using the wrong type of name
+        with self.assertRaises(ValueError):
+            Name(metric=Name(spec='design_gri'))
+
+    def test_fully_qualified_specification_name(self):
+        """Creating fully-qualified specification name."""
+        ref_name = Name(package='validate_drp',
+                        metric='PA1',
+                        spec='design_gri')
+
+        self.assertEqual(
+            ref_name,
+            Name('validate_drp.PA1.design_gri')
+        )
+
+        # using a Name
+        self.assertEqual(
+            ref_name,
+            Name(ref_name)
+        )
+
+        self.assertEqual(
+            ref_name,
+            Name('validate_drp.PA1.design_gri',
+                 metric='PA1', spec='design_gri')
+        )
+
+    def test_relative_spec_name(self):
+        """Creating a relative specification name."""
+        ref_name = Name(metric='PA1',
+                        spec='design_gri')
+
+        self.assertEqual(
+            ref_name,
+            Name(spec='PA1.design_gri')
+        )
+
+        # Use a Name
+        self.assertEqual(
+            ref_name,
+            Name(spec=Name(metric='PA1', spec='design_gri'))
+        )
+
+        self.assertEqual(
+            ref_name,
+            Name(metric='PA1', spec='PA1.design_gri')
+        )
+
+        with self.assertRaises(ValueError):
+            Name(metric='PA2', spec='PA1.design_gri')
+
+    def test_specification_name(self):
+        """Creating a bare specification name."""
+        ref_name = Name(spec='design_gri')
+
+        # Ensure that Name can be used in addition to a string
+        self.assertEqual(
+            ref_name,
+            Name(spec=Name(spec='design_gri'))
+        )
+
+        # Using the wrong type of Name
+        with self.assertRaises(ValueError):
+            Name(spec=Name('validate_drp.PA1'))
+
+    def test_package_name(self):
+        """Creating a package name."""
+        # Ensure that Name can be used in addition to a string
+        self.assertEqual(
+            Name('validate_drp'),
+            Name(package=Name(package='validate_drp'))
+        )
+
+
 class FullyQualifiedMetricName(unittest.TestCase):
     """Simple fully-qualified metric name."""
 
@@ -166,6 +284,16 @@ class FullyQualifiedSpecificationName(unittest.TestCase):
 
     def test_spec_name(self):
         self.assertEqual(self.name.spec, 'design_gri')
+
+        with self.assertRaises(ValueError):
+            Name('validate_drp.PA1.design_gri', spec='minimum')
+
+        with self.assertRaises(ValueError):
+            Name('validate_drp.PA1.design_gri', metric='PA2')
+
+        # Can't create a specification with a metric gap
+        with self.assertRaises(ValueError):
+            Name(package='validate_drp', spec='design')
 
     def test_fqn(self):
         self.assertEqual(
@@ -411,6 +539,9 @@ class PackageName(unittest.TestCase):
         )
 
     def test_eq(self):
+        self.assertTrue(
+            self.name == Name('validate_drp')
+        )
         self.assertTrue(
             self.name == Name(package='validate_drp'))
         self.assertFalse(

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,390 @@
+# See COPYRIGHT file at the top of the source tree.
+from __future__ import print_function, division
+
+import unittest
+
+from lsst.validate.base.naming import Name
+
+
+class FullyQualifiedMetricName(unittest.TestCase):
+    """Simple fully-qualified metric name."""
+
+    def setUp(self):
+        self.name = Name(package='validate_drp', metric='PA1')
+
+    def test_package_name(self):
+        self.assertEqual(self.name.package, 'validate_drp')
+
+    def test_metric_name(self):
+        self.assertEqual(self.name.metric, 'PA1')
+
+    def test_spec_name(self):
+        self.assertIsNone(self.name.spec)
+
+    def test_fqn(self):
+        self.assertEqual(
+            self.name.fqn,
+            'validate_drp.PA1')
+
+    def test_relative_name(self):
+        with self.assertRaises(AttributeError):
+            self.name.relative_name
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.name),
+            "Name('validate_drp', 'PA1')")
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.name),
+            'validate_drp.PA1'
+        )
+
+    def test_has_package(self):
+        self.assertTrue(self.name.has_package)
+
+    def test_has_metric(self):
+        self.assertTrue(self.name.has_metric)
+
+    def test_has_spec(self):
+        self.assertFalse(self.name.has_spec)
+
+    def test_has_relative(self):
+        self.assertFalse(self.name.has_relative)
+
+    def test_is_package(self):
+        self.assertFalse(self.name.is_package)
+
+    def test_is_metric(self):
+        self.assertTrue(self.name.is_metric)
+
+    def test_is_spec(self):
+        self.assertFalse(self.name.is_spec)
+
+    def test_is_fq(self):
+        self.assertTrue(self.name.is_fq)
+
+    def test_is_relative(self):
+        self.assertFalse(self.name.is_relative)
+
+
+class MetricName(unittest.TestCase):
+    """Metric name (not fully qualified)."""
+
+    def setUp(self):
+        self.name = Name(metric='PA1')
+
+    def test_package_name(self):
+        self.assertIsNone(self.name.package)
+
+    def test_metric_name(self):
+        self.assertEqual(self.name.metric, 'PA1')
+
+    def test_spec_name(self):
+        self.assertIsNone(self.name.spec)
+
+    def test_fqn(self):
+        with self.assertRaises(AttributeError):
+            self.name.fqn,
+
+    def test_relative_name(self):
+        with self.assertRaises(AttributeError):
+            self.name.relative_name
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.name),
+            "Name(metric='PA1')")
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.name),
+            'PA1'
+        )
+
+    def test_has_package(self):
+        self.assertFalse(self.name.has_package)
+
+    def test_has_metric(self):
+        self.assertTrue(self.name.has_metric)
+
+    def test_has_spec(self):
+        self.assertFalse(self.name.has_spec)
+
+    def test_has_relative(self):
+        self.assertFalse(self.name.has_relative)
+
+    def test_is_package(self):
+        self.assertFalse(self.name.is_package)
+
+    def test_is_metric(self):
+        self.assertTrue(self.name.is_metric)
+
+    def test_is_spec(self):
+        self.assertFalse(self.name.is_spec)
+
+    def test_is_fq(self):
+        self.assertFalse(self.name.is_fq)
+
+    def test_is_relative(self):
+        self.assertFalse(self.name.is_relative)
+
+
+class FullyQualifiedSpecificationName(unittest.TestCase):
+    """Simple fully-qualified specification name."""
+
+    def setUp(self):
+        self.name = Name(package='validate_drp',
+                         metric='PA1',
+                         spec='design_gri')
+
+    def test_package_name(self):
+        self.assertEqual(self.name.package, 'validate_drp')
+
+    def test_metric_name(self):
+        self.assertEqual(self.name.metric, 'PA1')
+
+    def test_spec_name(self):
+        self.assertEqual(self.name.spec, 'design_gri')
+
+    def test_fqn(self):
+        self.assertEqual(
+            self.name.fqn,
+            'validate_drp.PA1.design_gri')
+
+    def test_relative_name(self):
+        self.assertEqual(
+            self.name.relative_name,
+            'PA1.design_gri')
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.name),
+            "Name('validate_drp', 'PA1', 'design_gri')")
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.name),
+            'validate_drp.PA1.design_gri'
+        )
+
+    def test_has_package(self):
+        self.assertTrue(self.name.has_package)
+
+    def test_has_metric(self):
+        self.assertTrue(self.name.has_metric)
+
+    def test_has_spec(self):
+        self.assertTrue(self.name.has_spec)
+
+    def test_has_relative(self):
+        self.assertTrue(self.name.has_relative)
+
+    def test_is_package(self):
+        self.assertFalse(self.name.is_package)
+
+    def test_is_metric(self):
+        self.assertFalse(self.name.is_metric)
+
+    def test_is_spec(self):
+        self.assertTrue(self.name.is_spec)
+
+    def test_is_fq(self):
+        self.assertTrue(self.name.is_fq)
+
+    def test_is_relative(self):
+        self.assertFalse(self.name.is_relative)
+
+
+class RelativeSpecificationName(unittest.TestCase):
+    """Metric-relative specification name."""
+
+    def setUp(self):
+        self.name = Name(metric='PA1',
+                         spec='design_gri')
+
+    def test_package_name(self):
+        self.assertIsNone(self.name.package)
+
+    def test_metric_name(self):
+        self.assertEqual(self.name.metric, 'PA1')
+
+    def test_spec_name(self):
+        self.assertEqual(self.name.spec, 'design_gri')
+
+    def test_fqn(self):
+        with self.assertRaises(AttributeError):
+            self.name.fqn
+
+    def test_relative_name(self):
+        self.assertEqual(
+            self.name.relative_name,
+            'PA1.design_gri')
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.name),
+            "Name(metric='PA1', spec='design_gri')")
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.name),
+            'PA1.design_gri'
+        )
+
+    def test_has_package(self):
+        self.assertFalse(self.name.has_package)
+
+    def test_has_metric(self):
+        self.assertTrue(self.name.has_metric)
+
+    def test_has_spec(self):
+        self.assertTrue(self.name.has_spec)
+
+    def test_has_relative(self):
+        self.assertTrue(self.name.has_relative)
+
+    def test_is_package(self):
+        self.assertFalse(self.name.is_package)
+
+    def test_is_metric(self):
+        self.assertFalse(self.name.is_metric)
+
+    def test_is_spec(self):
+        self.assertTrue(self.name.is_spec)
+
+    def test_is_fq(self):
+        self.assertFalse(self.name.is_fq)
+
+    def test_is_relative(self):
+        self.assertTrue(self.name.is_relative)
+
+
+class SpecificationName(unittest.TestCase):
+    """A bare specification name."""
+
+    def setUp(self):
+        self.name = Name(spec='design_gri')
+
+    def test_package_name(self):
+        self.assertIsNone(self.name.package)
+
+    def test_metric_name(self):
+        self.assertIsNone(self.name.metric)
+
+    def test_spec_name(self):
+        self.assertEqual(self.name.spec, 'design_gri')
+
+    def test_fqn(self):
+        with self.assertRaises(AttributeError):
+            self.name.fqn
+
+    def test_relative_name(self):
+        with self.assertRaises(AttributeError):
+            self.name.relative_name
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.name),
+            "Name(spec='design_gri')")
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.name),
+            'design_gri'
+        )
+
+    def test_has_package(self):
+        self.assertFalse(self.name.has_package)
+
+    def test_has_metric(self):
+        self.assertFalse(self.name.has_metric)
+
+    def test_has_spec(self):
+        self.assertTrue(self.name.has_spec)
+
+    def test_has_relative(self):
+        self.assertFalse(self.name.has_relative)
+
+    def test_is_package(self):
+        self.assertFalse(self.name.is_package)
+
+    def test_is_metric(self):
+        self.assertFalse(self.name.is_metric)
+
+    def test_is_spec(self):
+        self.assertTrue(self.name.is_spec)
+
+    def test_is_fq(self):
+        self.assertFalse(self.name.is_fq)
+
+    def test_is_relative(self):
+        self.assertFalse(self.name.is_relative)
+
+
+class PackageName(unittest.TestCase):
+    """Package name."""
+
+    def setUp(self):
+        self.name = Name(package='validate_drp')
+
+    def test_package_name(self):
+        self.assertEqual(self.name.package, 'validate_drp')
+
+    def test_metric_name(self):
+        self.assertIsNone(self.name.metric)
+
+    def test_spec_name(self):
+        self.assertIsNone(self.name.spec)
+
+    def test_fqn(self):
+        self.assertEqual(
+            self.name.fqn,
+            'validate_drp')
+
+    def test_relative_name(self):
+        with self.assertRaises(AttributeError):
+            self.name.relative_name
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.name),
+            "Name('validate_drp')")
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.name),
+            'validate_drp'
+        )
+
+    def test_has_package(self):
+        self.assertTrue(self.name.has_package)
+
+    def test_has_metric(self):
+        self.assertFalse(self.name.has_metric)
+
+    def test_has_spec(self):
+        self.assertFalse(self.name.has_spec)
+
+    def test_has_relative(self):
+        self.assertFalse(self.name.has_relative)
+
+    def test_is_package(self):
+        self.assertTrue(self.name.is_package)
+
+    def test_is_metric(self):
+        self.assertFalse(self.name.is_metric)
+
+    def test_is_spec(self):
+        self.assertFalse(self.name.is_spec)
+
+    def test_is_fq(self):
+        self.assertTrue(self.name.is_fq)
+
+    def test_is_relative(self):
+        self.assertFalse(self.name.is_relative)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`Name` is intended to be a fairly Pythonic class for representing the name of a specification, metric, or package.

Class initialization is flexible. Some examples:

```python
Name(package='validate_drp', metric='PA1', spec='design') == Name('validate_drp.PA1.design')

metric_name = Name('validate_drp')
spec_name Name(metric=metric_name, spec='design')
```

`__eq__` and `__contains__` are both implemented. You can do:

```python
Name('validate_drp.PA1.design') in Name('validate_drp')
Name('validate_drp.PA1.design') in Name('validate_drp.PA1')
```

Properties give access to fully-qualified names:

```python
spec_name = Name(package='validate_drp', metric='PA1', spec='design')
spec_name.fqn == 'validate_drp.PA1.design'
spec_name.relative_name == 'PA1.design'

metric_name = Name(package='validate_drp', metric='PA1')
metric_name.fqn == 'validate_drp.PA1'
```

Both `__str__` and `__repr__` are implemented:

```python
>>> str(Name(package='validate_drp', metric='PA1', spec='design'))
'validate_drp.PA1.design'
>>> repr(Name(package='validate_drp', metric='PA1'))
"Name(package='validate_drp', metric='PA1')"
```

There's also a host of `is_*` and `has_*` properties to tell whether a name represents a metric, specification or package, or contains information about those.

I think we can use the `Name` class as the common internal representation of all package/metric/specification names in the framework.

I've also unit tested the heck out of this.